### PR TITLE
File forwarding

### DIFF
--- a/Voltaire/Controllers/Messages/Send.cs
+++ b/Voltaire/Controllers/Messages/Send.cs
@@ -51,7 +51,7 @@ namespace Voltaire.Controllers.Messages
                         { //TODO SendFileAsync DONE
                             return attachmentIndex < 0 ?
                                 channel.SendMessageAsync(view.Item1, embed: view.Item2) :
-                                channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? view.Item1 : "", embed: view.Item2);
+                                channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, view.Item1, embed: attachmentIndex == 0 ? view.Item2 : null);
                         }, context);
                     }
 
@@ -83,7 +83,7 @@ namespace Voltaire.Controllers.Messages
                 { //TODO SendFileAsync DONE
                     return attachmentIndex < 0 ?
                         channel.SendMessageAsync(view.Item1, embed: view.Item2) :
-                    channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? view.Item1 : "", embed: view.Item2);
+                    channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, view.Item1, embed: attachmentIndex == 0 ? view.Item2 : null);
                 }, context);
             };
         }

--- a/Voltaire/Controllers/Messages/Send.cs
+++ b/Voltaire/Controllers/Messages/Send.cs
@@ -5,7 +5,9 @@ using Discord.WebSocket;
 using Rijndael256;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,6 +15,8 @@ namespace Voltaire.Controllers.Messages
 {
     class Send
     {
+        private static HttpClient client = new HttpClient();
+
         public static async Task PerformAsync(ShardedCommandContext context, string channelName, string message, bool reply, DataBase db)
         {
             var candidateGuilds = GuildList(context);
@@ -31,32 +35,56 @@ namespace Voltaire.Controllers.Messages
             }
         }
 
-        public static Func<string, string, Task<IUserMessage>> SendMessageToChannel(IMessageChannel channel, bool replyable, ShardedCommandContext context, bool forceEmbed = false)
+        public static Func<string, string, Task<IUserMessage>> SendMessageToChannel(IMessageChannel channel, bool replyable, ShardedCommandContext context, bool forceEmbed = false, int attachmentIndex = -1)
         {
             if (!replyable)
             {
                 return async (username, message) =>
                 {
+                    Stream file = attachmentIndex < 0 ? null : await client.GetStreamAsync(context.Message.Attachments.ElementAt(attachmentIndex).Url);
+
                     message = CheckForMentions(channel, message);
                     if (forceEmbed)
                     {
                         var view = Views.Message.Response(username, message, null);
-                        return await SendMessageAndCatchError(() => { return channel.SendMessageAsync(view.Item1, embed: view.Item2); }, context);
+                        return await SendMessageAndCatchError(() =>
+                        { //TODO SendFileAsync DONE
+                            return attachmentIndex < 0 ?
+                                channel.SendMessageAsync(view.Item1, embed: view.Item2) :
+                                channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? view.Item1 : "", embed: view.Item2);
+                        }, context);
                     }
 
                     if (string.IsNullOrEmpty(username))
                     {
-                        return await SendMessageAndCatchError(() => { return channel.SendMessageAsync(message); }, context);
+                        return await SendMessageAndCatchError(() =>
+                        { //TODO SendFileAsync DONE
+                            return attachmentIndex < 0 ?
+                                channel.SendMessageAsync(message) :
+                                channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? message : "");
+                        }, context);
                     }
-                    return await SendMessageAndCatchError(() => { return channel.SendMessageAsync($"**{username}**: {message}"); }, context);
+                    return await SendMessageAndCatchError(() =>
+                    { //TODO SendFileAsync DONE
+                        return attachmentIndex < 0 ?
+                            channel.SendMessageAsync($"**{username}**: {message}") :
+                        channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? $"**{username}**: {message}" : "");
+                    }, context);
                 };
             }
             return async (username, message) =>
             {
+                Stream file = attachmentIndex < 0 ? null : await client.GetStreamAsync(context.Message.Attachments.ElementAt(attachmentIndex).Url);
+
                 var key = LoadConfig.Instance.config["encryptionKey"];
                 var replyHash = Rijndael.Encrypt(context.User.Id.ToString(), key, KeySize.Aes256);
                 var view = Views.Message.Response(username, message, replyHash.ToString());
-                return await SendMessageAndCatchError(() => { return channel.SendMessageAsync(view.Item1, embed: view.Item2); }, context);
+                return await SendMessageAndCatchError(() =>
+                { //TODO SendFileAsync DONE
+                    return attachmentIndex < 0 ?
+                        channel.SendMessageAsync(view.Item1, embed: view.Item2) :
+                    channel.SendFileAsync(file, context.Message.Attachments.ElementAt(attachmentIndex).Filename, attachmentIndex == 0 ? view.Item1 : "", embed: view.Item2);
+                }, context);
             };
         }
 

--- a/Voltaire/Controllers/Messages/SendDirectMessage.cs
+++ b/Voltaire/Controllers/Messages/SendDirectMessage.cs
@@ -64,9 +64,21 @@ namespace Voltaire.Controllers.Messages
 
                 var userChannel = await userGuild.Item1.GetOrCreateDMChannelAsync();
                 var prefix = PrefixHelper.ComputePrefix(context, userGuild.Item2, "anonymous user");
-                var messageFunction = Send.SendMessageToChannel(userChannel, replyable, context);
-                var sentMessage = await messageFunction(prefix, message);
-                await Send.AddReactionToMessage(sentMessage);
+                if (context.Message.Attachments.Any())
+                {
+                    for (int attachmentIndex = 0; attachmentIndex < context.Message.Attachments.Count; attachmentIndex++)
+                    {
+                        var messageFunction = Send.SendMessageToChannel(userChannel, replyable, context, false, attachmentIndex);
+                        var sentMessage = await messageFunction(prefix, message);
+                        await Send.AddReactionToMessage(sentMessage);
+                    }
+                }
+                else
+                {
+                    var messageFunction = Send.SendMessageToChannel(userChannel, replyable, context);
+                    var sentMessage = await messageFunction(prefix, message);
+                    await Send.AddReactionToMessage(sentMessage);
+                }
                 await Send.SendSentEmote(context);
             }
             catch (Exception ex)

--- a/Voltaire/Controllers/Messages/SendReply.cs
+++ b/Voltaire/Controllers/Messages/SendReply.cs
@@ -18,7 +18,7 @@ namespace Voltaire.Controllers.Messages
             // TODO: potentially want to bake guilds into reply codes so we can ensure that the the replier isn't banned on the server where the original
             // message was sent
             var users = SendDirectMessage.ToUserList(candidateGuilds).Where(x => x.Id.ToString() == candidateId);
-            if(users.Count() == 0)
+            if (users.Count() == 0)
             {
                 await Send.SendErrorWithDeleteReaction(context, "Something is wrong with that reply code. It is possible the sender has left your server.");
                 return;
@@ -36,9 +36,21 @@ namespace Voltaire.Controllers.Messages
 
             // all 'users' here are technically the same user, so just take the first
             var channel = await users.First().GetOrCreateDMChannelAsync();
-            var messageFunction = Send.SendMessageToChannel(channel, replyable, context);
-            var sentMessage = await messageFunction(prefix, message);
-            await Send.AddReactionToMessage(sentMessage);
+            if (context.Message.Attachments.Any())
+            {
+                for (int attachmentIndex = 0; attachmentIndex < context.Message.Attachments.Count; attachmentIndex++)
+                {
+                    var messageFunction = Send.SendMessageToChannel(channel, replyable, context, false, attachmentIndex);
+                    var sentMessage = await messageFunction(prefix, message);
+                    await Send.AddReactionToMessage(sentMessage);
+                }
+            }
+            else
+            {
+                var messageFunction = Send.SendMessageToChannel(channel, replyable, context);
+                var sentMessage = await messageFunction(prefix, message);
+                await Send.AddReactionToMessage(sentMessage);
+            }
             await Send.SendSentEmote(context);
         }
     }

--- a/Voltaire/Controllers/Messages/SendToGuild.cs
+++ b/Voltaire/Controllers/Messages/SendToGuild.cs
@@ -56,7 +56,7 @@ namespace Voltaire.Controllers.Messages
                 return;
             }
 
-            if(!IncrementAndCheckMessageLimit.Perform(dbGuild, db))
+            if (!IncrementAndCheckMessageLimit.Perform(dbGuild, db))
             {
                 await Send.SendErrorWithDeleteReaction(context, "This server has reached its limit of 50 messages for the month. To lift this limit, ask an admin or moderator to upgrade your server to Voltaire Pro. (This can be done via the `!volt pro` command.)");
                 return;
@@ -64,8 +64,19 @@ namespace Voltaire.Controllers.Messages
 
             var prefix = PrefixHelper.ComputePrefix(context, dbGuild);
             var channel = candidateChannels.OrderBy(x => x.Name.Length).First();
-            var messageFunction = Send.SendMessageToChannel(channel, replyable, context, dbGuild.UseEmbed);
-            await messageFunction(prefix, message);
+            if (context.Message.Attachments.Any())
+            {
+                for (int attachmentIndex = 0; attachmentIndex < context.Message.Attachments.Count; attachmentIndex++)
+                {
+                    var messageFunction = Send.SendMessageToChannel(channel, replyable, context, dbGuild.UseEmbed, attachmentIndex);
+                    await messageFunction(prefix, message);
+                }
+            }
+            else
+            {
+                var messageFunction = Send.SendMessageToChannel(channel, replyable, context, dbGuild.UseEmbed);
+                await messageFunction(prefix, message);
+            }
             await Send.SendSentEmote(context);
             return;
         }


### PR DESCRIPTION
Allow Voltaire to forward files that it receives as attachments.
If it were just single attachments the flow would be quite simple, but Discord Mobile allows for multiple attachments in one message, which the Discord.NET API does not allow. The flow got quite messy as a result but it works. 
While most of the code is still Asynchronous, the changes were made so that the attachments are still sent in the same order they arrived, inside the original message.
I haven't used any lambdas (yet), just simple old Java-like logic.